### PR TITLE
Fix Vercel build

### DIFF
--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -1,8 +1,8 @@
 export async function readInputForDay(
     day: number, 
-    useSampleData: Boolean = false,
+    useSampleData: boolean = false,
 ): Promise<string> {
-    var filePath = `inputs/day${day}`;
+    let filePath = `inputs/day${day}`;
     if (useSampleData) {
         filePath += "-sample";
     }

--- a/src/solutions/day1.ts
+++ b/src/solutions/day1.ts
@@ -1,8 +1,8 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(1, useSampleData);
-    var [leftList, rightList] = parseLists(input);
+    let [leftList, rightList] = parseLists(input);
 
     // sort the lists and sum the difference between each item
     leftList = leftList.sort();
@@ -14,14 +14,14 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return totalDistance;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(1, useSampleData);
     const [leftList, rightList] = parseLists(input);
     
-    var similarityScore = 0;
-    for (var left = 0; left < leftList.length; left++) {
-        var count = 0;
-        for (var right = 0; right < rightList.length; right++) {
+    let similarityScore = 0;
+    for (let left = 0; left < leftList.length; left++) {
+        let count = 0;
+        for (let right = 0; right < rightList.length; right++) {
             if (rightList[right] === leftList[left]) {
                 count += 1;
             }

--- a/src/solutions/day2.ts
+++ b/src/solutions/day2.ts
@@ -1,13 +1,13 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(2, useSampleData);
     const lines = input.trim().split('\n');
 
-    var safeReports = 0;
+    let safeReports = 0;
     lines.map(line => {
         const report = line.split(/\s+/).map(Number);
-        const [isSafe, _] = isReportSafe(report)
+        const [isSafe] = isReportSafe(report)
         if (isSafe) {
             safeReports++;
         }
@@ -16,11 +16,11 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return safeReports;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(2, useSampleData);
     const lines = input.trim().split('\n');
 
-    var safeReports = 0;
+    let safeReports = 0;
     lines.map(line => {
         const report = line.split(/\s+/).map(Number);
         const [isSafe, problemIndex] = isReportSafe(report);
@@ -29,9 +29,9 @@ export async function part2(useSampleData: Boolean = false): Promise<number> {
         } else {
             const lowerBound = Math.max(problemIndex - 2, 0);
             const upperBound = Math.min(problemIndex + 2, report.length);
-            for (var i = lowerBound; i < upperBound; i++) {
+            for (let i = lowerBound; i < upperBound; i++) {
                 const reportWithRemoval = report.filter((_, index) => index !== i);
-                const [isSafeWithRemoval, _] = isReportSafe(reportWithRemoval);
+                const [isSafeWithRemoval] = isReportSafe(reportWithRemoval);
                 if (isSafeWithRemoval) {
                     safeReports++;
                     break;
@@ -47,8 +47,8 @@ export async function part2(useSampleData: Boolean = false): Promise<number> {
 // true otherwise.
 function isReportSafe(report: number[]): [boolean, number] {
     // if the first is bigger than the second, the whole list should decrease
-    var shouldDecrease = report[0] > report[1];
-    for (var i = 1; i < report.length; i++) {
+    const shouldDecrease = report[0] > report[1];
+    for (let i = 1; i < report.length; i++) {
         if (shouldDecrease && report[i] >= report[i-1]) {
             return [false, i];
         }

--- a/src/solutions/day3.ts
+++ b/src/solutions/day3.ts
@@ -1,10 +1,10 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(3, useSampleData);
     const mulInstructions = parseMulInstructions(input, false);
 
-    var sum = 0;
+    let sum = 0;
     for (const instruction of mulInstructions) {
         sum += instruction[0] * instruction[1];
     }
@@ -12,11 +12,11 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return sum;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(3, useSampleData);
     const mulInstructions = parseMulInstructions(input, true);
 
-    var sum = 0;
+    let sum = 0;
     for (const instruction of mulInstructions) {
         sum += instruction[0] * instruction[1];
     }
@@ -28,13 +28,13 @@ type MulInstruction = [number, number];
 
 function parseMulInstructions(input: string, withConditionals: boolean): MulInstruction[] {
     const regex = /(mul\([0-9]+,[0-9]+\))|(do(n't)?\(\))/g;
-    var mulInstructions: MulInstruction[] = [];
+    const mulInstructions: MulInstruction[] = [];
     const matches = input.match(regex);
     if (!matches || matches.length === 0) { // if we have no matches return empty list
         return [];
     }
 
-    var mulIsDisabled = false;
+    let mulIsDisabled = false;
     for (const match of matches) {
         if (match === "don't()") {
             // mul instructions are now disabled

--- a/src/solutions/day4.ts
+++ b/src/solutions/day4.ts
@@ -1,11 +1,11 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(4, useSampleData);
     const wordSearch = parseWordSearch(input);
     const allXs = findAllChars(wordSearch, 'X');
 
-    var numXmas = 0;
+    let numXmas = 0;
     for (const x of allXs) {
         numXmas += numWordsAtPosition(wordSearch, x, 'XMAS').length;
     }
@@ -13,12 +13,12 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return numXmas;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(4, useSampleData);
     const wordSearch = parseWordSearch(input);
     const allMs = findAllChars(wordSearch, 'M');
 
-    var masLocations: [Position, Direction][] = [];
+    const masLocations: [Position, Direction][] = [];
     for (const m of allMs) {
         // only look for words 'MAS' in the diaganol directions
         for (const masFound of numWordsAtPosition(wordSearch, m, 'MAS', false)) {
@@ -29,9 +29,9 @@ export async function part2(useSampleData: Boolean = false): Promise<number> {
     // find all the A's that are a part of 2 different MAS words - these are the 'X'
     // formation 'MAS's
     const allAs = findAllChars(wordSearch, 'A');
-    var numMas = 0;
+    let numMas = 0;
     for (const a of allAs) {
-        var numWordsMatched = 0;
+        let numWordsMatched = 0;
         for (const mas of masLocations) {
             const aLocation = applyDirection(mas[0], mas[1]);
             if (aLocation[0] === a[0] && aLocation[1] === a[1]) {
@@ -57,10 +57,10 @@ function parseWordSearch(input: string): WordSearch {
 }
 
 function findAllChars(wordSearch: WordSearch, char: string): Position[] {
-    var positions: Position[] = []
+    const positions: Position[] = []
     wordSearch.forEach((row, rowIndex) => {
-        row.forEach((char, colIndex) => {
-            if (char === char) {
+        row.forEach((rowChar, colIndex) => {
+            if (rowChar === char) {
                 positions.push([rowIndex, colIndex]);
             }
         });
@@ -79,8 +79,8 @@ function numWordsAtPosition(
     word: string,
     includeNonDiaganols: boolean = true
 ): Direction[] {
-    var directionsToReturn: Direction[] = [];
-    var directionsToCheck: Direction[] = [
+    const directionsToReturn: Direction[] = [];
+    const directionsToCheck: Direction[] = [
         [-1, -1], [-1, 1], [1, -1], [1, 1] // up-left, up-right, down-left, down-right
     ];
     if (includeNonDiaganols) {
@@ -89,7 +89,7 @@ function numWordsAtPosition(
         directionsToCheck.push([-1, 0], [1, 0], [0, -1], [0, 1]) // up, down, left, right
     }
 
-    for (let [dx, dy] of directionsToCheck) {
+    for (const [dx, dy] of directionsToCheck) {
         let valid = true;
         for (let i = 0; i < word.length; i++) {
             const newRow = position[0] + (i * dx);

--- a/src/solutions/day5.ts
+++ b/src/solutions/day5.ts
@@ -1,12 +1,12 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(5, useSampleData);
     const instructions = parseInstructions(input);
     
     const sortedUpdates = sortUpdates(instructions);
 
-    var middleValueSum = 0;
+    let middleValueSum = 0;
     sortedUpdates.validUpdates
         .map((validUpdate) => getMiddleValue(validUpdate))
         .forEach((middleValue) => { middleValueSum += middleValue; });
@@ -14,12 +14,12 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return middleValueSum;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(5, useSampleData);
     const instructions = parseInstructions(input);
 
     const sortedUpdates = sortUpdates(instructions);
-    var middleValueSum = 0;
+    let middleValueSum = 0;
     sortedUpdates.invalidUpdates
         .map((invalidUpdate) => fixUpdate(invalidUpdate, instructions))
         .map((validUpdate) => getMiddleValue(validUpdate))
@@ -47,10 +47,10 @@ type PageOrderingRules = Map<number, number[]>
 function parseInstructions(input: string): Instructions {
     const [ruleSection, updateSection] = input.split('\n\n');
 
-    var rules: Map<number, number[]> = new Map();
+    const rules: Map<number, number[]> = new Map();
     ruleSection.split('\n').forEach((rule) => {
         const [first, second] = rule.split('|').map((num) => parseInt(num));
-        var ruleToAdd = rules.get(first);
+        let ruleToAdd = rules.get(first);
         if (!ruleToAdd) {
             ruleToAdd = []
         }
@@ -68,8 +68,8 @@ function parseInstructions(input: string): Instructions {
 }
 
 function sortUpdates(instructions: Instructions): SortedUpdates {
-    var validUpdates = [];
-    var invalidUpdates = [];
+    const validUpdates = [];
+    const invalidUpdates = [];
     for (const update of instructions.pageUpdates) {
         const [isValid] = isUpdateValid(update, instructions.rules);
         if (isValid) {
@@ -89,8 +89,8 @@ function sortUpdates(instructions: Instructions): SortedUpdates {
 // true otherwise.
 // The offending rule is represented as the number that was printed before but should have been printed after.
 function isUpdateValid(update: number[], rules: PageOrderingRules): [boolean, number, number] {
-    var pagesSeen: number[] = [];
-    for (var i = 0; i < update.length; i++) {
+    const pagesSeen: number[] = [];
+    for (let i = 0; i < update.length; i++) {
         const page = update[i];
         const rulePages = rules.get(page);
         if (rulePages) {
@@ -106,8 +106,8 @@ function isUpdateValid(update: number[], rules: PageOrderingRules): [boolean, nu
 }
 
 function fixUpdate(update: number[], instructions: Instructions): number[] {
-    var [isNowValid, index, rule] = isUpdateValid(update, instructions.rules);
-    var newUpdate = update;
+    let [isNowValid, index, rule] = isUpdateValid(update, instructions.rules);
+    const newUpdate = update.slice();
     while (!isNowValid) {
         // swap the indices and try again
         const ruleIndex = update.indexOf(rule);

--- a/src/solutions/day6.ts
+++ b/src/solutions/day6.ts
@@ -1,6 +1,6 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(6, useSampleData);
     const map = parseMap(input);
     const { visitedPositions } = predictGuardRoute(map);
@@ -8,13 +8,12 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return visitedPositions.uniquePositionsSize();
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(6, useSampleData);
     const map = parseMap(input);
     
     // check all positions where obstacles could be placed
-    let viableObstacles: Position[] = [];
-    var max = map.length * map[0].length;
+    const viableObstacles: Position[] = [];
     for (let row = 0; row < map.length; row++) {
         for (let col = 0; col < map[row].length; col++) {
             if (map[row][col] === '.') {
@@ -68,8 +67,8 @@ class UniquePositionsSet {
     // Return the size of unique positions (ignoring direction)
     uniquePositionsSize(): number {
         const uniquePositions = new Set();
-        for (let key of this.set) {
-            const [position, _] = key.split('-');
+        for (const key of this.set) {
+            const [position] = key.split('-');
             uniquePositions.add(position);
         }
         return uniquePositions.size;
@@ -101,7 +100,7 @@ function predictGuardRoute(
     
     while (true) {
         let [row, col] = guard;
-        let [dRow, dCol] = deltas[direction];
+        const [dRow, dCol] = deltas[direction];
         row += dRow;
         col += dCol;
 
@@ -112,7 +111,7 @@ function predictGuardRoute(
 
         // Check if the guard hits an obstacle
         if (map[row][col] === '#') {
-            let currentDirectionIndex = directions.indexOf(direction);
+            const currentDirectionIndex = directions.indexOf(direction);
             direction = directions[(currentDirectionIndex + 1) % 4];
             continue;
         }

--- a/src/solutions/day7.ts
+++ b/src/solutions/day7.ts
@@ -1,6 +1,6 @@
 import { readInputForDay } from '@/common/file';
 
-export async function part1(useSampleData: Boolean = false): Promise<number> {
+export async function part1(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(7, useSampleData);
     const instructions = parseInstructions(input);
 
@@ -12,7 +12,7 @@ export async function part1(useSampleData: Boolean = false): Promise<number> {
     return sum;
 }
 
-export async function part2(useSampleData: Boolean = false): Promise<number> {
+export async function part2(useSampleData: boolean = false): Promise<number> {
     const input = await readInputForDay(7, useSampleData);
     const instructions = parseInstructions(input);
 


### PR DESCRIPTION
I didn't realize when I was writing my solutions that I was breaking some Typescript rules. They didn't block compilation or running the solutions, but did result in compiler warnings (which weren't being printed during development) which blocked my [Vercel](https://vercel.com/) deploy.

Most of the errors were simple, like using `var` instead of `let`. The most surprising was using `_` in `[foo, _]` to suppress the second element of a tuple. I took that as a Kotlin convention, but turns out that TypeScript considers `_` to be a valid identifier and thought I was assigning the second tuple element to a variable named `_`. I forgot that in javascript and TypeScript you can just ignore shit, so the correct way to ignore the other element is simply to write `[foo]`. To me that's confusing implicit behavior, but it works for TypeScript.

Plus, now that I'm integrated in Vercel I see a preview and WOW! The Vercel dev environment is phenomenal. It's so cool that in the time it took me to type this comment, Vercel deployed and authenticated preview environment for my website that I can use to check that everything works. Talk about iterative development!